### PR TITLE
Refresh versions across repository

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,16 +35,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}

--- a/BASE_IMAGE
+++ b/BASE_IMAGE
@@ -1,1 +1,1 @@
-docker.io/kindest/base:v20221025-014d1502
+docker.io/kindest/base:v20230310-474355fc


### PR DESCRIPTION
Updated base image, github action verisons and setup dependabot. This will resume building images for latest master as there has been no activity in the repository in the recent past.

Tested the base image build against kubernetes/kubernetes master. 
<img width="906" alt="image" src="https://github.com/ppc64le-cloud/kind-image/assets/110517346/7d80e1e0-3a66-4f23-bfa5-1afe66b57d93">
