### PR TITLE
Build kind-node images from latest base image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,13 +16,6 @@ on:
   pull_request:
     branches: [ "main", 'v*.*.*' ]
 
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: quay.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: powercloud/kind-node
-
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,6 +25,12 @@ jobs:
       fail-fast: false
       matrix:
         version: ["master"]
+    env:
+      # Use docker.io for Docker Hub if empty
+      REGISTRY: quay.io
+      # github.repository as <account>/<repo>
+      IMAGE_NAME: powercloud/kind-node
+
 
     steps:
       - name: Checkout repository
@@ -56,20 +55,27 @@ jobs:
           BASE_IMAGE=$(cat BASE_IMAGE)
           echo "KIND_VERSION=$KIND_VERSION" >> $GITHUB_ENV
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_ENV
+          export PATH=$PATH:$(go env GOPATH)/bin
+          echo "PATH=$PATH" >> $GITHUB_ENV
 
-      - name: Install kind
+      - name: Build and install kind - ${{ env.KIND_VERSION }}
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/${{ env.KIND_VERSION }}/kind-linux-amd64
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
+          # The runner has kind pre-installed, removing the same to install the preferred version.
+          rm -rf $(which kind)
+          git clone --depth 1 --branch ${{ env.KIND_VERSION }} https://github.com/kubernetes-sigs/kind.git
+          pushd kind
+          git apply ../build-ppc64le.patch 
+          popd
 
-      - name: Build kind image
+          make -C kind install
+
+      - name: Build kind-node image - ${{ matrix.version }}
         run: |
           mkdir -p tmp/kubernetes
-          git clone --single-branch --branch ${{ matrix.version }} https://github.com/kubernetes/kubernetes tmp/kubernetes
-          kind build node-image $PWD/tmp/kubernetes --arch ppc64le --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.version }} --base-image ${{ env.BASE_IMAGE }} 
+          git clone --single-branch --filter=tree:0 --branch ${{ matrix.version }} https://github.com/kubernetes/kubernetes tmp/kubernetes
+          kind build node-image $PWD/tmp/kubernetes --arch ppc64le --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.version }} --base-image ${{ env.BASE_IMAGE }}
 
-      - name: Publish image
+      - name: Publish node image
         if: github.event_name != 'pull_request'
         run: |
           docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.version }}

--- a/BASE_IMAGE
+++ b/BASE_IMAGE
@@ -1,1 +1,1 @@
-docker.io/kindest/base:v20230310-474355fc
+quay.io/powercloud/kind-base:v20240626-0296c52

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # kind-image
+Kind-node image for the PowerPC architecture.
 
 Images are hosted at https://quay.io/repository/powercloud/kind-node?tab=tags and can be used as follows:
 
 ```shell
-$ kind create cluster --image quay.io/powercloud/kind-node:v1.25.0
+$ kind create cluster --image quay.io/powercloud/kind-node:v1.30.2
 ```

--- a/build-ppc64le.patch
+++ b/build-ppc64le.patch
@@ -44,3 +44,44 @@ index f8226e1..dc9980f 100755
    *)
      exit 1 ;;
  esac
+diff --git a/pkg/build/nodeimage/const_cni.go b/pkg/build/nodeimage/const_cni.go
+index 6715884..f7a8e88 100644
+--- a/pkg/build/nodeimage/const_cni.go
++++ b/pkg/build/nodeimage/const_cni.go
+@@ -20,7 +20,7 @@ package nodeimage
+ The default CNI manifest and images are our own tiny kindnet
+ */
+ 
+-const kindnetdImage = "docker.io/kindest/kindnetd:v20240513-cd2ac642"
++const kindnetdImage = "quay.io/powercloud/kind-kindnetd:v20240626-0296c52"
+ 
+ var defaultCNIImages = []string{kindnetdImage}
+ 
+diff --git a/pkg/build/nodeimage/const_storage.go b/pkg/build/nodeimage/const_storage.go
+index 7ddb8a6..03815e0 100644
+--- a/pkg/build/nodeimage/const_storage.go
++++ b/pkg/build/nodeimage/const_storage.go
+@@ -25,8 +25,8 @@ NOTE: we have customized it in the following ways:
+ - install as the default storage class
+ */
+ 
+-const storageProvisionerImage = "docker.io/kindest/local-path-provisioner:v20240513-b9bba138"
+-const storageHelperImage = "docker.io/kindest/local-path-helper:v20230510-486859a6"
++const storageProvisionerImage = "quay.io/powercloud/kind-local-path-provisioner:v20240626-0296c52"
++const storageHelperImage = "quay.io/powercloud/kind-local-path-helper:v20240626-0296c52"
+ 
+ // image we need to preload
+ var defaultStorageImages = []string{storageProvisionerImage, storageHelperImage}
+diff --git a/pkg/cluster/internal/loadbalancer/const.go b/pkg/cluster/internal/loadbalancer/const.go
+index 3600b33..e84bf8c 100644
+--- a/pkg/cluster/internal/loadbalancer/const.go
++++ b/pkg/cluster/internal/loadbalancer/const.go
+@@ -17,7 +17,7 @@ limitations under the License.
+ package loadbalancer
+ 
+ // Image defines the loadbalancer image:tag
+-const Image = "docker.io/kindest/haproxy:v20230606-42a2262b"
++const Image = "quay.io/powercloud/kind-haproxy:v20240626-0296c52"
+ 
+ // ConfigPath defines the path to the config file in the image
+ const ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
Changes: 
Build kind from latest base image.
Use latest kindnetd and local-path-provisioner images in kind cluster.
Fetch k8s version from https://dl.k8s.io/release/stable.txt
Dispatch workflows manually from main branch for building on latest stable k8s.

Todos post-merge:
move base-image, kindnetd, local-path-helper and local-path-helper to quay.io/powercloud.
