### PR TITLE
Accept k8s version to build node images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,14 +7,16 @@ name: Docker
 
 on:
   workflow_dispatch:
-  schedule:
-    # Build the job every day for the master branch
-    - cron: '0 0 * * *'
+    inputs:
+      k8s-version:
+        description: 'The kubernetes version to be used for building node image.'
+        default: 'master'
+        required: false
+        type: string
   push:
-    branches: [ "main", 'v*.*.*' ]
-    tags: [ 'v*.*.*' ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", 'v*.*.*' ]
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -23,13 +25,15 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
-      matrix:
-        version: ["master"]
     env:
       # Use docker.io for Docker Hub if empty
       REGISTRY: quay.io
       # github.repository as <account>/<repo>
       IMAGE_NAME: powercloud/kind-node
+      # Until variables are available across different github_events as a feature,
+      # this operation can set a default value for k8s-version to 'master'
+      # https://github.com/orgs/community/discussions/26322#discussioncomment-3251442
+      K8S-VERSION: ${{ inputs.k8s-version || 'master' }}
 
 
     steps:
@@ -69,13 +73,15 @@ jobs:
 
           make -C kind install
 
-      - name: Build kind-node image - ${{ matrix.version }}
+      - name: Build kind-node image - ${{ env.K8S-VERSION}}
         run: |
           mkdir -p tmp/kubernetes
-          git clone --single-branch --filter=tree:0 --branch ${{ matrix.version }} https://github.com/kubernetes/kubernetes tmp/kubernetes
-          kind build node-image $PWD/tmp/kubernetes --arch ppc64le --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.version }} --base-image ${{ env.BASE_IMAGE }}
+          git clone --single-branch --filter=tree:0 --branch ${{ env.K8S-VERSION }} https://github.com/kubernetes/kubernetes tmp/kubernetes
+          kind build node-image $PWD/tmp/kubernetes --arch ppc64le --image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.K8S-VERSION }} --base-image ${{ env.BASE_IMAGE }}
 
-      - name: Publish node image
-        if: github.event_name != 'pull_request'
+      - name: Publish node image - ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.K8S-VERSION }}
+        # Modifying or adding new changes to the workflow does not necessarily require the built image to be pushed.
+        # Images can solely be built through workflow dispatch.
+        if: github.event_name != 'pull_request' && github.event_name != 'push'
         run: |
-          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.version }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.K8S-VERSION }}


### PR DESCRIPTION
Changes: 
1. Accept version of k8s as an input to the workflow to build kind-node images.
2. Refer to `vars.QUAY_USERNAME` from the earlier `secrets.QUAY_USERNAME` (requires changes in the repository setting to have this variable defined)

The docker workflow tends to fail as k8s-version is defaulting to `null` rather than `master`. However, subsequent builds seem to run fine.

```
##[debug]Evaluating: format('Build kind-node image - {0}', inputs.k8s-version)
[50](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:54)
##[debug]Evaluating format:
[51](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:55)
##[debug]..Evaluating String:
[52](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:56)
##[debug]..=> 'Build kind-node image - {0}'
[53](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:57)
##[debug]..Evaluating Index:
[54](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:58)
##[debug]....Evaluating inputs:
[55](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:59)
##[debug]....=> Object
[56](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:60)
##[debug]....Evaluating String:
[57](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:61)
##[debug]....=> 'k8s-version'
[58](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:62)
##[debug]..=> null.   <--------------------
[59](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:63)
##[debug]=> 'Build kind-node image - '
[60](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:64)
##[debug]Result: 'Build kind-node image - '
[61](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:65)
##[debug]Set step '__run_3' display name to: 'Build kind-node image - '
[62](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:66)
##[debug]Set step '__run_4' display name to: 'Publish node image'
[63](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:67)
Complete job name: build
[64](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:68)
##[debug]Collect running processes for tracking orphan processes.
[65](https://github.com/kishen-v/kind-image/actions/runs/9937700804/job/27450385411#step:1:69)
##[debug]Finishing: Set up job
```
vs.
```
##[debug]Evaluating format:
[51](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:55)
##[debug]..Evaluating String:
[52](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:56)
##[debug]..=> 'Build kind-node image - {0}'
[53](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:57)
##[debug]..Evaluating Index:
[54](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:58)
##[debug]....Evaluating inputs:
[55](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:59)
##[debug]....=> Object
[56](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:60)
##[debug]....Evaluating String:
[57](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:61)
##[debug]....=> 'k8s-version'
[58](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:62)
##[debug]..=> 'master' <------------
[59](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:63)
##[debug]=> 'Build kind-node image - master'
[60](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:64)
##[debug]Result: 'Build kind-node image - master'
[61](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:65)
##[debug]Set step '__run_3' display name to: 'Build kind-node image - master'
[62](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:66)
##[debug]Set step '__run_4' display name to: 'Publish node image'
[63](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:67)
Complete job name: build
[64](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:68)
##[debug]Collect running processes for tracking orphan processes.
[65](https://github.com/kishen-v/kind-image/actions/runs/9938312957/job/27450516466#step:1:69)
##[debug]Finishing: Set up job
```

<img width="1091" alt="image" src="https://github.com/user-attachments/assets/58b34a95-5555-42be-9a39-be018300b24e">
