### PR TITLE
Update base and other dependent images for kind

### DIFF
--- a/BASE_IMAGE
+++ b/BASE_IMAGE
@@ -1,1 +1,1 @@
-quay.io/powercloud/kind-base:v20240626-0296c52
+quay.io/powercloud/kind-base:v20250520-6cb9342

--- a/build-ppc64le.patch
+++ b/build-ppc64le.patch
@@ -67,7 +67,7 @@ index df601536..e2050319 100644
      && mv bin/local-path-provisioner-$TARGETARCH /usr/local/bin/local-path-provisioner \
      && GOBIN=/usr/local/bin go install github.com/google/go-licenses@latest \
 diff --git a/pkg/build/nodeimage/const_cni.go b/pkg/build/nodeimage/const_cni.go
-index a1c870c9..4568afbd 100644
+index a1c870c9..408cb333 100644
 --- a/pkg/build/nodeimage/const_cni.go
 +++ b/pkg/build/nodeimage/const_cni.go
 @@ -20,7 +20,7 @@ package nodeimage
@@ -75,12 +75,12 @@ index a1c870c9..4568afbd 100644
  */
  
 -const kindnetdImage = "docker.io/kindest/kindnetd:v20250214-acbabc1a"
-+const kindnetdImage = "quay.io/powercloud/kind-kindnetd:v20240626-0296c52"
++const kindnetdImage = "quay.io/powercloud/kind-kindnetd:v20250520-6cb9342"
  
  var defaultCNIImages = []string{kindnetdImage}
  
 diff --git a/pkg/build/nodeimage/const_storage.go b/pkg/build/nodeimage/const_storage.go
-index 0f4806bf..c887b3fe 100644
+index 0f4806bf..bc1ff3e0 100644
 --- a/pkg/build/nodeimage/const_storage.go
 +++ b/pkg/build/nodeimage/const_storage.go
 @@ -26,8 +26,8 @@ NOTE: we have customized it in the following ways:
@@ -89,13 +89,13 @@ index 0f4806bf..c887b3fe 100644
  
 -const storageProvisionerImage = "docker.io/kindest/local-path-provisioner:v20250214-acbabc1a"
 -const storageHelperImage = "docker.io/kindest/local-path-helper:v20241212-8ac705d0"
-+const storageProvisionerImage = "quay.io/powercloud/kind-local-path-provisioner:v20240626-0296c52"
-+const storageHelperImage = "quay.io/powercloud/kind-local-path-helper:v20240626-0296c52"
++const storageProvisionerImage = "quay.io/powercloud/kind-local-path-provisioner:v20250520-6cb9342"
++const storageHelperImage = "quay.io/powercloud/kind-local-path-helper:v20250520-6cb9342"
  
  // image we need to preload
  var defaultStorageImages = []string{storageProvisionerImage, storageHelperImage}
 diff --git a/pkg/cluster/internal/loadbalancer/const.go b/pkg/cluster/internal/loadbalancer/const.go
-index 3600b338..e84bf8c4 100644
+index 3600b338..0651b43c 100644
 --- a/pkg/cluster/internal/loadbalancer/const.go
 +++ b/pkg/cluster/internal/loadbalancer/const.go
 @@ -17,7 +17,7 @@ limitations under the License.
@@ -103,7 +103,7 @@ index 3600b338..e84bf8c4 100644
  
  // Image defines the loadbalancer image:tag
 -const Image = "docker.io/kindest/haproxy:v20230606-42a2262b"
-+const Image = "quay.io/powercloud/kind-haproxy:v20240626-0296c52"
++const Image = "quay.io/powercloud/kind-haproxy:v20250520-6cb9342"
  
  // ConfigPath defines the path to the config file in the image
  const ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
Latest components built through:
https://github.com/ppc64le-cloud/kind-image/actions/runs/15130233077

Fixes: #42 

Built a custom image and tested the built node image
```
[root@p10-image-builder kind]# kubectl get nodes -w
NAME                 STATUS   ROLES           AGE   VERSION
kind-control-plane   Ready    control-plane   34s   v1.33.1
kind-worker          Ready    <none>          17s   v1.33.1
kind-worker2         Ready    <none>          17s   v1.33.1
kind-worker3         Ready    <none>          18s   v1.33.1


[root@p10-image-builder kind]# kubectl get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
kube-system          coredns-674b8bbfcf-5rgxl                     1/1     Running   0          37s
kube-system          coredns-674b8bbfcf-rjhfw                     1/1     Running   0          37s
kube-system          etcd-kind-control-plane                      1/1     Running   0          46s
kube-system          kindnet-lztvt                                1/1     Running   0          30s
kube-system          kindnet-mxwq9                                1/1     Running   0          31s
kube-system          kindnet-qnz2c                                1/1     Running   0          30s
kube-system          kindnet-qvp66                                1/1     Running   0          37s
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          44s
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          44s
kube-system          kube-proxy-5nfvl                             1/1     Running   0          30s
kube-system          kube-proxy-98cxn                             1/1     Running   0          30s
kube-system          kube-proxy-lvj8k                             1/1     Running   0          37s
kube-system          kube-proxy-n5t68                             1/1     Running   0          31s
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          44s
local-path-storage   local-path-provisioner-68667798c6-pk7kn      1/1     Running   0          37s
```