### PR TITLE
Refer rancher/local-path-provisioner with the latest changes.

### DIFF
--- a/build-ppc64le.patch
+++ b/build-ppc64le.patch
@@ -45,24 +45,15 @@ index f8226e15..dc9980f1 100755
      exit 1 ;;
  esac
 diff --git a/images/local-path-provisioner/Dockerfile b/images/local-path-provisioner/Dockerfile
-index df601536..f42072b5 100644
+index df601536..29f3f216 100644
 --- a/images/local-path-provisioner/Dockerfile
 +++ b/images/local-path-provisioner/Dockerfile
-@@ -15,7 +15,7 @@
- # NOTE the actual go version will be overridden
- FROM --platform=$BUILDPLATFORM docker.io/library/golang:latest
- COPY --chmod=0755 scripts/third_party/gimme/gimme /usr/local/bin/
--RUN git clone --filter=tree:0 https://github.com/rancher/local-path-provisioner
-+RUN git clone --filter=tree:0 --branch=ppc64le-support https://github.com/kishen-v/local-path-provisioner
- ARG VERSION
- # set by makefile to .go-version
- # TODO: scripts/build builds for multiple platforms, so we waste a little time here
 @@ -23,7 +23,7 @@ ARG TARGETARCH GO_VERSION
  RUN eval "$(gimme "${GO_VERSION}")" \
      && export GOTOOLCHAIN="go${GO_VERSION}" \
      && cd local-path-provisioner \
 -    && git fetch && git checkout "${VERSION}" \
-+    # && git fetch && git checkout "${VERSION}" \
++    # && git fetch && git checkout "${VERSION}" \ # kind/images/local-path-provisioner/Makefile - Until v0.0.32 is released
      && GOARCH=$TARGETARCH scripts/build \
      && mv bin/local-path-provisioner-$TARGETARCH /usr/local/bin/local-path-provisioner \
      && GOBIN=/usr/local/bin go install github.com/google/go-licenses@latest \


### PR DESCRIPTION

Latest rancher/local-path-provisioner supports building images for ppc64le:
 https://github.com/rancher/local-path-provisioner/pull/492