### PR TITLE
Update BASE_IMAGE based on kind v0.32.0

### DIFF
--- a/BASE_IMAGE
+++ b/BASE_IMAGE
@@ -1,1 +1,1 @@
-quay.io/powercloud/kind-base:v20250520-6cb9342
+quay.io/powercloud/kind-base:v20260624-v0.32.0

--- a/build-ppc64le.patch
+++ b/build-ppc64le.patch
@@ -67,7 +67,7 @@ index 80e9351..b539c06 100644
  */
  
 -const kindnetdImage = "docker.io/kindest/kindnetd:v20260528-9350166c"
-+const kindnetdImage = "quay.io/powercloud/kind-kindnetd:v20250520-6cb9342"
++const kindnetdImage = "quay.io/powercloud/kind-kindnetd:v20260624-v0.32.0"
  
  var defaultCNIImages = []string{kindnetdImage}
  
@@ -81,8 +81,8 @@ index 2d1db53..bc1ff3e 100644
  
 -const storageProvisionerImage = "docker.io/kindest/local-path-provisioner:v20260521-9fb22683"
 -const storageHelperImage = "docker.io/kindest/local-path-helper:v20260131-7181c60a"
-+const storageProvisionerImage = "quay.io/powercloud/kind-local-path-provisioner:v20250520-6cb9342"
-+const storageHelperImage = "quay.io/powercloud/kind-local-path-helper:v20250520-6cb9342"
++const storageProvisionerImage = "quay.io/powercloud/kind-local-path-provisioner:v20260624-v0.32.0"
++const storageHelperImage = "quay.io/powercloud/kind-local-path-helper:v20260624-v0.32.0"
  
  // image we need to preload
  var defaultStorageImages = []string{storageProvisionerImage, storageHelperImage}


### PR DESCRIPTION
This PR updates the BASE_IMAGE used for building kind-node images, along with the bump in the cluster component specific images to the latest available versions. 

Follow-up to #77