### PR TITLE
Add groups for GitHub Actions packages in dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      github-actions-packages:
+        patterns:
+          - '*'


### PR DESCRIPTION
Groups the dependabot action related version bumps as a grouped update.